### PR TITLE
Remove misleading double quotes in stack file

### DIFF
--- a/tutum.yml
+++ b/tutum.yml
@@ -3,4 +3,4 @@ ubuntu:
   ports:
     - 2222:22
   environment:
-    - AUTHORIZED_KEYS="YOUR SSH PUBLIC KEY HERE"
+    - AUTHORIZED_KEYS=YOUR SSH PUBLIC KEY HERE


### PR DESCRIPTION
User needs to provide ssh pub key without double quotes.

If user leaves the double quotes, the resulting stack file is created in Tutum like below:

ubuntu:
  image: 'tutum/ubuntu:latest'
  environment:
    - 'AUTHORIZED_KEYS="YOUR SSH PUBLIC KEY HERE"'
  ports:
    - '2222:22'

Container deployment logs will then show (notice doubles quotes here):
2015-07-06T20:52:53.994433980Z => Adding public key to /root/.ssh/authorized_keys: "YOUR SSH PUBLIC KEY HERE"

And in the container, we can then see:

root@ubuntu-1:~# cat .ssh/authorized_keys 
"YOUR SSH PUBLIC KEY HERE"

Obviously (even with the correct ssh key), it will show something like "ssh-rsa AAAAB3NzaC..." (with double quotes). Consequence is user cannot login with provided ssh key as file content isnt properly formated.
